### PR TITLE
Fix this error: Project xxx tried to find library 'record_ros'.  The …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ generate_messages(
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS roscpp message_runtime std_msgs
 #  DEPENDS system_lib
 )


### PR DESCRIPTION
…library   is neither a target nor built/installed properly.  Did you compile project   'record_ros'? Did you find_package() it before the subdirectory containing   its code is included?